### PR TITLE
Split forward into lib.rs for use as a library

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
-/target/
 **/*.rs.bk
+.idea/
+.vscode/
+target/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,9 +22,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "futures"
-version = "0.3.24"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f21eda599937fba36daeb58a22e8f5cee2d14c4a17b5b7739c7c8e5e3b8230c"
+checksum = "38390104763dc37a5145a53c29c63c1290b5d316d6086ec32c293f6736051bb0"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -37,9 +37,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.24"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30bdd20c28fadd505d0fd6712cdfcb0d4b5648baf45faef7f852afb2399bb050"
+checksum = "52ba265a92256105f45b719605a571ffe2d1f0fea3807304b522c1d778f79eed"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -47,15 +47,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.24"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e5aa3de05362c3fb88de6531e6296e85cde7739cccad4b9dfeeb7f6ebce56bf"
+checksum = "04909a7a7e4633ae6c4a9ab280aeb86da1236243a77b694a49eacd659a4bd3ac"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.24"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ff63c23854bee61b6e9cd331d523909f238fc7636290b96826e9cfa5faa00ab"
+checksum = "7acc85df6714c176ab5edf386123fafe217be88c0840ec11f199441134a074e2"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -64,15 +64,15 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.24"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbf4d2a7a308fd4578637c0b17c7e1c7ba127b8f6ba00b29f717e9655d85eb68"
+checksum = "00f5fb52a06bdcadeb54e8d3671f8888a39697dcb0b81b23b55174030427f4eb"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.24"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42cd15d1c7456c04dbdf7e88bcd69760d74f3a798d6444e16974b505b0e62f17"
+checksum = "bdfb8ce053d86b91919aad980c220b1fb8401a9394410e1c289ed7e66b61835d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -81,21 +81,21 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.24"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b20ba5a92e727ba30e72834706623d94ac93a725410b6a6b6fbc1b07f7ba56"
+checksum = "39c15cf1a4aa79df40f1bb462fb39676d0ad9e366c2a33b590d7c66f4f81fcf9"
 
 [[package]]
 name = "futures-task"
-version = "0.3.24"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6508c467c73851293f390476d4491cf4d227dbabcd4170f3bb6044959b294f1"
+checksum = "2ffb393ac5d9a6eaa9d3fdf37ae2776656b706e200c8e16b1bdb227f5198e6ea"
 
 [[package]]
 name = "futures-util"
-version = "0.3.24"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44fb6cb1be61cc1d2e43b262516aafcf63b241cffdb1d3fa115f91d9c7b09c90"
+checksum = "197676987abd2f9cadff84926f410af1c183608d36641465df73ae8211dc65d6"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -157,7 +157,7 @@ dependencies = [
  "libc",
  "log",
  "wasi",
- "windows-sys",
+ "windows-sys 0.36.1",
 ]
 
 [[package]]
@@ -232,7 +232,7 @@ dependencies = [
 
 [[package]]
 name = "tcpproxy"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "futures",
  "getopts",
@@ -241,9 +241,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.21.2"
+version = "1.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9e03c497dc955702ba729190dc4aac6f2a0ce97f913e5b1b5912fc5039d9099"
+checksum = "1d9f76183f91ecfb55e1d7d5602bd1d979e38a3a522fe900241cf195624d67ae"
 dependencies = [
  "autocfg",
  "bytes",
@@ -254,7 +254,7 @@ dependencies = [
  "pin-project-lite",
  "socket2",
  "tokio-macros",
- "winapi",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -314,12 +314,33 @@ version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea04155a16a59f9eab786fe12a4a450e75cdb175f9e0d80da1e17db09f55b8d2"
 dependencies = [
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_msvc",
+ "windows_aarch64_msvc 0.36.1",
+ "windows_i686_gnu 0.36.1",
+ "windows_i686_msvc 0.36.1",
+ "windows_x86_64_gnu 0.36.1",
+ "windows_x86_64_msvc 0.36.1",
 ]
+
+[[package]]
+name = "windows-sys"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc 0.42.1",
+ "windows_i686_gnu 0.42.1",
+ "windows_i686_msvc 0.42.1",
+ "windows_x86_64_gnu 0.42.1",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc 0.42.1",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c9864e83243fdec7fc9c5444389dcbbfd258f745e7853198f365e3c4968a608"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -328,10 +349,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9bb8c3fd39ade2d67e9874ac4f3db21f0d710bee00fe7cab16949ec184eeaa47"
 
 [[package]]
+name = "windows_aarch64_msvc"
+version = "0.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c8b1b673ffc16c47a9ff48570a9d85e25d265735c503681332589af6253c6c7"
+
+[[package]]
 name = "windows_i686_gnu"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "180e6ccf01daf4c426b846dfc66db1fc518f074baa793aa7d9b9aaeffad6a3b6"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de3887528ad530ba7bdbb1faa8275ec7a1155a45ffa57c37993960277145d640"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -340,13 +373,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2e7917148b2812d1eeafaeb22a97e4813dfa60a3f8f78ebe204bcc88f12f024"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf4d1122317eddd6ff351aa852118a2418ad4214e6613a50e0191f7004372605"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4dcd171b8776c41b97521e5da127a2d86ad280114807d0b2ab1e462bc764d9e1"
 
 [[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1040f221285e17ebccbc2591ffdc2d44ee1f9186324dd3e84e99ac68d699c45"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "628bfdf232daa22b0d64fdb62b09fcc36bb01f05a3939e20ab73aaf9470d0463"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "447660ad36a13288b1db4d4248e857b510e8c3a225c822ba4fb748c0aafecffd"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 keywords = ["proxy", "tcp", "networking", "tokio"]
 categories = ["command-line-utilities", "network-programming"]
 license = "MIT"
-edition = "2021"
+edition = "2018"
 
 [dependencies]
 futures = "0.3.25"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tcpproxy"
-version = "0.3.1"
+version = "0.3.2"
 authors = ["Mahmoud Al-Qudsi <mqudsi@neosmart.net>"]
 description = "Cross-platform asynchronous multi-client TCP proxy; great tokio demo."
 homepage = "https://github.com/neosmart/tcpproxy"
@@ -9,9 +9,9 @@ readme = "README.md"
 keywords = ["proxy", "tcp", "networking", "tokio"]
 categories = ["command-line-utilities", "network-programming"]
 license = "MIT"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
-futures = "0.3.24"
+futures = "0.3.25"
 getopts = "0.2.21"
-tokio = { version = "1.21.2", features = [ "io-util", "net", "rt-multi-thread", "macros", "sync" ] }
+tokio = { version = "1.24.1", features = ["io-util", "net", "rt-multi-thread", "macros", "sync"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,126 @@
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use futures::FutureExt;
+use tokio::{
+    io::{AsyncReadExt, AsyncWriteExt},
+    net::{TcpListener, TcpStream},
+    sync::broadcast,
+};
+
+pub type BoxedError = Box<dyn std::error::Error + Sync + Send + 'static>;
+pub static DEBUG: AtomicBool = AtomicBool::new(false);
+const BUF_SIZE: usize = 1024;
+
+pub async fn forward(bind_ip: &str, local_port: i32, remote: &str) -> Result<(), BoxedError> {
+    // Listen on the specified IP and port
+    let bind_addr = if !bind_ip.starts_with('[') && bind_ip.contains(':') {
+        // Correctly format for IPv6 usage
+        format!("[{}]:{}", bind_ip, local_port)
+    } else {
+        format!("{}:{}", bind_ip, local_port)
+    };
+    let bind_sock = bind_addr
+        .parse::<std::net::SocketAddr>()
+        .expect("Failed to parse bind address");
+    let listener = TcpListener::bind(&bind_sock).await?;
+    println!("Listening on {}", listener.local_addr().unwrap());
+
+    // We have either been provided an IP address or a host name.
+    let remote = std::sync::Arc::new(remote.to_string());
+
+    async fn copy_with_abort<R, W>(
+        read: &mut R,
+        write: &mut W,
+        mut abort: broadcast::Receiver<()>,
+    ) -> tokio::io::Result<usize>
+    where
+        R: tokio::io::AsyncRead + Unpin,
+        W: tokio::io::AsyncWrite + Unpin,
+    {
+        let mut copied = 0;
+        let mut buf = [0u8; BUF_SIZE];
+        loop {
+            let bytes_read;
+            tokio::select! {
+                biased;
+
+                result = read.read(&mut buf) => {
+                    bytes_read = result?;
+                },
+                _ = abort.recv() => {
+                    break;
+                }
+            }
+
+            if bytes_read == 0 {
+                break;
+            }
+
+            write.write_all(&buf[0..bytes_read]).await?;
+            copied += bytes_read;
+        }
+
+        Ok(copied)
+    }
+
+    loop {
+        let remote = remote.clone();
+        let (mut client, client_addr) = listener.accept().await?;
+
+        tokio::spawn(async move {
+            println!("New connection from {}", client_addr);
+
+            // Establish connection to upstream for each incoming client connection
+            let mut remote = TcpStream::connect(remote.as_str()).await?;
+            let (mut client_read, mut client_write) = client.split();
+            let (mut remote_read, mut remote_write) = remote.split();
+
+            let (cancel, _) = broadcast::channel::<()>(1);
+            let (remote_copied, client_copied) = tokio::join! {
+                copy_with_abort(&mut remote_read, &mut client_write, cancel.subscribe())
+                    .then(|r| { let _ = cancel.send(()); async { r } }),
+                copy_with_abort(&mut client_read, &mut remote_write, cancel.subscribe())
+                    .then(|r| { let _ = cancel.send(()); async { r } }),
+            };
+
+            match client_copied {
+                Ok(count) => {
+                    if DEBUG.load(Ordering::Relaxed) {
+                        eprintln!(
+                            "Transferred {} bytes from remote client {} to upstream server",
+                            count, client_addr
+                        );
+                    }
+                }
+                Err(err) => {
+                    eprintln!(
+                        "Error writing bytes from remote client {} to upstream server",
+                        client_addr
+                    );
+                    eprintln!("{}", err);
+                }
+            };
+
+            match remote_copied {
+                Ok(count) => {
+                    if DEBUG.load(Ordering::Relaxed) {
+                        eprintln!(
+                            "Transferred {} bytes from upstream server to remote client {}",
+                            count, client_addr
+                        );
+                    }
+                }
+                Err(err) => {
+                    eprintln!(
+                        "Error writing from upstream server to remote client {}!",
+                        client_addr
+                    );
+                    eprintln!("{}", err);
+                }
+            };
+
+            let r: Result<(), BoxedError> = Ok(());
+            r
+        });
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,13 +1,11 @@
 use std::sync::atomic::{AtomicBool, Ordering};
-
 use futures::FutureExt;
-use tokio::{
-    io::{AsyncReadExt, AsyncWriteExt},
-    net::{TcpListener, TcpStream},
-    sync::broadcast,
-};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::{TcpListener, TcpStream};
+use tokio::sync::broadcast;
 
 pub type BoxedError = Box<dyn std::error::Error + Sync + Send + 'static>;
+
 pub static DEBUG: AtomicBool = AtomicBool::new(false);
 const BUF_SIZE: usize = 1024;
 
@@ -33,9 +31,9 @@ pub async fn forward(bind_ip: &str, local_port: i32, remote: &str) -> Result<(),
         write: &mut W,
         mut abort: broadcast::Receiver<()>,
     ) -> tokio::io::Result<usize>
-    where
-        R: tokio::io::AsyncRead + Unpin,
-        W: tokio::io::AsyncWrite + Unpin,
+        where
+            R: tokio::io::AsyncRead + Unpin,
+            W: tokio::io::AsyncWrite + Unpin,
     {
         let mut copied = 0;
         let mut buf = [0u8; BUF_SIZE];

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,6 @@
 use std::{env, sync::atomic::Ordering};
-
 use getopts::Options;
-use tcpproxy::{forward, BoxedError, DEBUG};
+use tcpproxy::{BoxedError, DEBUG, forward};
 
 fn print_usage(program: &str, opts: Options) {
     let program_path = std::path::PathBuf::from(program);
@@ -28,7 +27,7 @@ async fn main() -> Result<(), BoxedError> {
     opts.optopt(
         "l",
         "local-port",
-        "The local port to which tcp-proxy should bind to, randomly chosen otherwise",
+        "The local port to which tcpproxy should bind to, randomly chosen otherwise",
         "LOCAL_PORT",
     );
     opts.optflag("d", "debug", "Enable debug mode");

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,14 +1,7 @@
-use futures::FutureExt;
-use getopts::Options;
-use std::env;
-use std::sync::atomic::{AtomicBool, Ordering};
-use tokio::io::{AsyncReadExt, AsyncWriteExt};
-use tokio::net::{TcpListener, TcpStream};
-use tokio::sync::broadcast;
+use std::{env, sync::atomic::Ordering};
 
-type BoxedError = Box<dyn std::error::Error + Sync + Send + 'static>;
-static DEBUG: AtomicBool = AtomicBool::new(false);
-const BUF_SIZE: usize = 1024;
+use getopts::Options;
+use tcpproxy::{forward, BoxedError, DEBUG};
 
 fn print_usage(program: &str, opts: Options) {
     let program_path = std::path::PathBuf::from(program);
@@ -35,7 +28,7 @@ async fn main() -> Result<(), BoxedError> {
     opts.optopt(
         "l",
         "local-port",
-        "The local port to which tcpproxy should bind to, randomly chosen otherwise",
+        "The local port to which tcp-proxy should bind to, randomly chosen otherwise",
         "LOCAL_PORT",
     );
     opts.optflag("d", "debug", "Enable debug mode");
@@ -70,118 +63,4 @@ async fn main() -> Result<(), BoxedError> {
     };
 
     forward(&bind_addr, local_port, remote).await
-}
-
-async fn forward(bind_ip: &str, local_port: i32, remote: &str) -> Result<(), BoxedError> {
-    // Listen on the specified IP and port
-    let bind_addr = if !bind_ip.starts_with('[') && bind_ip.contains(':') {
-        // Correctly format for IPv6 usage
-        format!("[{}]:{}", bind_ip, local_port)
-    } else {
-        format!("{}:{}", bind_ip, local_port)
-    };
-    let bind_sock = bind_addr
-        .parse::<std::net::SocketAddr>()
-        .expect("Failed to parse bind address");
-    let listener = TcpListener::bind(&bind_sock).await?;
-    println!("Listening on {}", listener.local_addr().unwrap());
-
-    // We have either been provided an IP address or a host name.
-    let remote = std::sync::Arc::new(remote.to_string());
-
-    async fn copy_with_abort<R, W>(
-        read: &mut R,
-        write: &mut W,
-        mut abort: broadcast::Receiver<()>,
-    ) -> tokio::io::Result<usize>
-    where
-        R: tokio::io::AsyncRead + Unpin,
-        W: tokio::io::AsyncWrite + Unpin,
-    {
-        let mut copied = 0;
-        let mut buf = [0u8; BUF_SIZE];
-        loop {
-            let bytes_read;
-            tokio::select! {
-                biased;
-
-                result = read.read(&mut buf) => {
-                    bytes_read = result?;
-                },
-                _ = abort.recv() => {
-                    break;
-                }
-            }
-
-            if bytes_read == 0 {
-                break;
-            }
-
-            write.write_all(&buf[0..bytes_read]).await?;
-            copied += bytes_read;
-        }
-
-        Ok(copied)
-    }
-
-    loop {
-        let remote = remote.clone();
-        let (mut client, client_addr) = listener.accept().await?;
-
-        tokio::spawn(async move {
-            println!("New connection from {}", client_addr);
-
-            // Establish connection to upstream for each incoming client connection
-            let mut remote = TcpStream::connect(remote.as_str()).await?;
-            let (mut client_read, mut client_write) = client.split();
-            let (mut remote_read, mut remote_write) = remote.split();
-
-            let (cancel, _) = broadcast::channel::<()>(1);
-            let (remote_copied, client_copied) = tokio::join! {
-                copy_with_abort(&mut remote_read, &mut client_write, cancel.subscribe())
-                    .then(|r| { let _ = cancel.send(()); async { r } }),
-                copy_with_abort(&mut client_read, &mut remote_write, cancel.subscribe())
-                    .then(|r| { let _ = cancel.send(()); async { r } }),
-            };
-
-            match client_copied {
-                Ok(count) => {
-                    if DEBUG.load(Ordering::Relaxed) {
-                        eprintln!(
-                            "Transferred {} bytes from remote client {} to upstream server",
-                            count, client_addr
-                        );
-                    }
-                }
-                Err(err) => {
-                    eprintln!(
-                        "Error writing bytes from remote client {} to upstream server",
-                        client_addr
-                    );
-                    eprintln!("{}", err);
-                }
-            };
-
-            match remote_copied {
-                Ok(count) => {
-                    if DEBUG.load(Ordering::Relaxed) {
-                        eprintln!(
-                            "Transferred {} bytes from upstream server to remote client {}",
-                            count, client_addr
-                        );
-                    }
-                }
-                Err(err) => {
-                    eprintln!(
-                        "Error writing from upstream server to remote client {}!",
-                        client_addr
-                    );
-                    eprintln!("{}", err);
-                }
-            };
-
-            let r: Result<(), BoxedError> = Ok(());
-            r
-        });
-    }
 }


### PR DESCRIPTION
I split the forward function into lib.rs so it can be used in Rust projects as a library  
I also updated the rust edition, dependency versions, and the patch version number, this change doesn't break existing functionality.